### PR TITLE
Update to the Deployment Batch File

### DIFF
--- a/DeployToNuGet.bat
+++ b/DeployToNuGet.bat
@@ -1,8 +1,7 @@
 nuget.exe update -self
+ECHO Y | DEL *.nupkg
 
 #NOTE - Using an account for factorygirl@meinershagen.net to publish to NuGet.org.  This can be changed in the future.
 nuget.exe setApiKey 57dc68f8-50fb-46fe-a99b-175c9099673e
 nuget.exe pack FactoryGirl.NET\FactoryGirl.NET.csproj
-
-#NOTE - The version for this package name will need to be updated if the Assembly Version of Assembly File Version are changed.
-nuget.exe push FactoryGirl.NET.1.0.0.0.nupkg
+nuget.exe push *.nupkg


### PR DESCRIPTION
Hi James,

I updated the batch file to remove any NuGet packages before repackaging and push any NuGet package in the directory.  This means that the developer doesn't have to update the batch file whenever the version changes for the assembly.  Should be easier to maintain.

Thanks,

Todd
