### PR TITLE
Add Named Factories to FactoryGirl.Net

### DIFF
--- a/FactoryGirl.NET.Specs/FactoryGirlSpecs.cs
+++ b/FactoryGirl.NET.Specs/FactoryGirlSpecs.cs
@@ -9,16 +9,60 @@ namespace FactoryGirl.NET.Specs {
         public class When_we_define_a_factory {
             Establish context = () => { };
             Because of = () => FactoryGirl.Define(() => new Dummy());
-            It should_contain_the_definition = () => FactoryGirl.DefinedFactories.ShouldContain(typeof(Dummy));
+            It should_contain_the_definition = () => FactoryGirl.DefinedFactories.ShouldContain(FactoryGirl.GetName<Dummy>());
         }
 
         [Subject(typeof(FactoryGirl))]
-        public class When_a_factory_has_been_defined {
-            Establish context = () => FactoryGirl.Define(() => new Dummy());
+        public class When_we_define_a_named_factory
+        {
+            Establish context = () => { };
+            Because of = () => FactoryGirl.Define("test", () => new Dummy());
+            It should_contain_the_definition = () => FactoryGirl.DefinedFactories.ShouldContain(FactoryGirl.GetName<Dummy>("test"));
+        }
+
+
+        [Subject(typeof(FactoryGirl))]
+        public class When_a_named_factory_has_been_defined
+        {
+            private Establish context = () => FactoryGirl.Define("test", () => new Dummy());
+
+            [Subject(typeof(FactoryGirl))]
+            public class When_we_define_the_same_named_factory_again
+            {
+                Because of = () => exception = Catch.Exception(() => FactoryGirl.Define("test", () => new Dummy()));
+                It should_throw_a_DuplicateFactoryException = () => exception.ShouldBeOfType<DuplicateFactoryException>();
+
+                static Exception exception;
+            }
+
+            [Subject(typeof(FactoryGirl))]
+            public class When_we_build_a_named_default_object
+            {
+                Because of = () => builtObject = FactoryGirl.Build<Dummy>("test");
+                It should_build_the_object = () => builtObject.ShouldNotBeNull();
+                It should_assign_the_default_value_for_the_property = () => builtObject.Value.ShouldEqual(Dummy.DefaultValue);
+
+                static Dummy builtObject;
+            }
+
+            [Subject(typeof(FactoryGirl))]
+            public class When_we_build_a_named_customized_object
+            {
+                Because of = () => builtObject = FactoryGirl.Build<Dummy>("test", x => x.Value = 42);
+                It should_update_the_specified_value = () => builtObject.Value.ShouldEqual(42);
+
+                static Dummy builtObject;
+            }
+        }
+
+        [Subject(typeof(FactoryGirl))]
+        public class When_a_factory_has_been_defined
+        {
+            private Establish context = () => FactoryGirl.Define(() => new Dummy());
 
             [Subject(typeof(FactoryGirl))]
             public class When_we_define_the_same_factory_again {
-                Because of = () => exception = Catch.Exception(() => FactoryGirl.Define(() => new Dummy()));
+                Because of = () => exception = Catch.Exception(() => FactoryGirl.Define(() => new Dummy()));                
                 It should_throw_a_DuplicateFactoryException = () => exception.ShouldBeOfType<DuplicateFactoryException>();
 
                 static Exception exception;

--- a/FactoryGirl.NET/FactoryGirl.cs
+++ b/FactoryGirl.NET/FactoryGirl.cs
@@ -4,30 +4,83 @@ using System.Linq;
 
 namespace FactoryGirl.NET
 {
-    public static class FactoryGirl {
-        private static readonly IDictionary<Type, Func<object>> builders = new Dictionary<Type, Func<object>>();
- 
-        public static void Define<T>(Func<T> builder) {
-            if(builders.ContainsKey(typeof(T))) throw new DuplicateFactoryException(typeof(T).Name + " is already registered. You can only register one factory per type.");
-            builders.Add(typeof(T), () => builder());
+    public static class FactoryGirl
+    {
+
+        private static readonly IDictionary<String, Func<object>> namedBuilders = new Dictionary<string, Func<object>>();
+
+        public static void Define<T>(string name, Func<T> builder)
+        {
+            string keyname = GetName<T>(name);
+            Define<T>(builder, keyname);
         }
 
-        public static T Build<T>() {
-            return Build<T>(x => { });
+        public static void Define<T>(Func<T> builder)
+        {
+            var key = GetKeyForType<T>();
+            Define<T>(builder, key);
         }
 
-        public static T Build<T>(Action<T> overrides) {
-            var result = (T) builders[typeof(T)]();
+        public static T Build<T>()
+        {
+            return BuildObject<T>(x => { });
+        }
+
+        public static T Build<T>(string name)
+        {
+            return BuildObject<T>( x => { }, name);
+        }
+
+        public static T Build<T>(Action<T> overrides)
+        {
+            return BuildObject(overrides);
+        }
+
+        public static T Build<T>(string name, Action<T> overrides)
+        {
+            return BuildObject(overrides, name);
+        }
+
+        public static IEnumerable<string> DefinedFactories
+        {
+            get { return namedBuilders.Select(x => x.Key); }
+        }
+
+        public static string GetName<T>(string name = "")
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                return GetKeyForType<T>();
+            }
+
+            return GetKeyForType<T>() + "_" + name;
+        }
+
+        public static void ClearFactoryDefinitions()
+        {
+            namedBuilders.Clear();
+        }
+
+        private static T BuildObject<T>(Action<T> overrides, string key = "")
+        {
+            var keyName = GetName<T>(key);
+            var result = (T)namedBuilders[keyName]();
             overrides(result);
             return result;
         }
 
-        public static IEnumerable<Type> DefinedFactories {
-            get { return builders.Select(x => x.Key); }
+        private static void Define<T>(Func<T> builder, string key = "")
+        {
+            if (namedBuilders.ContainsKey(key)) throw new DuplicateFactoryException(key + " is already registered. You can only register one factory per type/name.");
+            namedBuilders.Add(key, () => builder());
         }
 
-        public static void ClearFactoryDefinitions() {
-            builders.Clear();
+        private static string GetKeyForType<T>()
+        {
+            var args = typeof(T).GetGenericArguments();
+            var key = typeof(T).Name;
+            args.ToList().ForEach(x => key += key + "_" + x);
+            return key;
         }
     }
 }


### PR DESCRIPTION
Unnamed Factories are still available the only difference is the key is a
string instead of the type of the object the factory builds

The named factories are built from the type of the object as well as from
the Generic Arguments and a key. This is different from @rbuskov 's implementation as defining List<Foo> and List<Bar> would throw a duplicate factory exception. 

.
