### PR TITLE
Add Named Factories to FactoryGirl.Net

### DIFF
--- a/FactoryGirl.NET.Specs/FactoryGirlSpecs.cs
+++ b/FactoryGirl.NET.Specs/FactoryGirlSpecs.cs
@@ -9,16 +9,60 @@ namespace FactoryGirl.NET.Specs {
         public class When_we_define_a_factory {
             Establish context = () => { };
             Because of = () => FactoryGirl.Define(() => new Dummy());
-            It should_contain_the_definition = () => FactoryGirl.DefinedFactories.ShouldContain(typeof(Dummy));
+            It should_contain_the_definition = () => FactoryGirl.DefinedFactories.ShouldContain(FactoryGirl.GetName<Dummy>());
         }
 
         [Subject(typeof(FactoryGirl))]
-        public class When_a_factory_has_been_defined {
-            Establish context = () => FactoryGirl.Define(() => new Dummy());
+        public class When_we_define_a_named_factory
+        {
+            Establish context = () => { };
+            Because of = () => FactoryGirl.Define("test", () => new Dummy());
+            It should_contain_the_definition = () => FactoryGirl.DefinedFactories.ShouldContain(FactoryGirl.GetName<Dummy>("test"));
+        }
+
+
+        [Subject(typeof(FactoryGirl))]
+        public class When_a_named_factory_has_been_defined
+        {
+            private Establish context = () => FactoryGirl.Define("test", () => new Dummy());
+
+            [Subject(typeof(FactoryGirl))]
+            public class When_we_define_the_same_named_factory_again
+            {
+                Because of = () => exception = Catch.Exception(() => FactoryGirl.Define("test", () => new Dummy()));
+                It should_throw_a_DuplicateFactoryException = () => exception.ShouldBeOfType<DuplicateFactoryException>();
+
+                static Exception exception;
+            }
+
+            [Subject(typeof(FactoryGirl))]
+            public class When_we_build_a_named_default_object
+            {
+                Because of = () => builtObject = FactoryGirl.Build<Dummy>("test");
+                It should_build_the_object = () => builtObject.ShouldNotBeNull();
+                It should_assign_the_default_value_for_the_property = () => builtObject.Value.ShouldEqual(Dummy.DefaultValue);
+
+                static Dummy builtObject;
+            }
+
+            [Subject(typeof(FactoryGirl))]
+            public class When_we_build_a_named_customized_object
+            {
+                Because of = () => builtObject = FactoryGirl.Build<Dummy>("test", x => x.Value = 42);
+                It should_update_the_specified_value = () => builtObject.Value.ShouldEqual(42);
+
+                static Dummy builtObject;
+            }
+        }
+
+        [Subject(typeof(FactoryGirl))]
+        public class When_a_factory_has_been_defined
+        {
+            private Establish context = () => FactoryGirl.Define(() => new Dummy());
 
             [Subject(typeof(FactoryGirl))]
             public class When_we_define_the_same_factory_again {
-                Because of = () => exception = Catch.Exception(() => FactoryGirl.Define(() => new Dummy()));
+                Because of = () => exception = Catch.Exception(() => FactoryGirl.Define(() => new Dummy()));                
                 It should_throw_a_DuplicateFactoryException = () => exception.ShouldBeOfType<DuplicateFactoryException>();
 
                 static Exception exception;


### PR DESCRIPTION
The named factories are built from the FullName of the object

Unnamed Factories are still available the only difference is the key is a
string instead of the type of the object the factory builds.
